### PR TITLE
Update Dockerfile to be able to build 17.04 ejabberd version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:jessie-slim
 MAINTAINER Rafael Römhild <rafael@roemhild.de>
 
-ENV EJABBERD_BRANCH=17.03 \
+ENV EJABBERD_BRANCH=17.04 \
     EJABBERD_USER=ejabberd \
     EJABBERD_HTTPS=true \
     EJABBERD_STARTTLS=true \
@@ -68,6 +68,7 @@ RUN set -x \
     && chmod +x ./autogen.sh \
     && ./autogen.sh \
     && ./configure --enable-user=$EJABBERD_USER \
+        --prefix=/ \
         --enable-all \
         --disable-tools \
         --disable-pam \


### PR DESCRIPTION
Because the default installation prefix has changed in the new release, it is needed to add in the configure line of Docker file the argument  --prefix=/

We are open to contributions for ejabberd, as GitHub pull requests (PR).
Here are a few points to consider before submitting your PR. (You can
remove the whole text after reading.)

Issuer related https://github.com/processone/ejabberd/issues/1695
